### PR TITLE
RFL-61 the extra-small checkbox is smaller than the small checkbox

### DIFF
--- a/packages/ui/src/components/checkbox/checkbox.module.css
+++ b/packages/ui/src/components/checkbox/checkbox.module.css
@@ -1,7 +1,7 @@
 :root {
   --ax-public-checkbox-size-medium: 1.25rem;
-  --ax-public-checkbox-size-small: 1rem;
-  --ax-public-checkbox-size-extra-small: 1.125rem;
+  --ax-public-checkbox-size-small: 1.125rem;
+  --ax-public-checkbox-size-extra-small: 1rem;
 
   --ax-public-checkbox-icon-size-medium: 0.875rem;
   --ax-public-checkbox-icon-size-small: 0.75rem;
@@ -9,22 +9,32 @@
 
   --ax-public-checkbox-border-radius-medium: var(--ax-token-radius-checkbox-m);
   --ax-public-checkbox-border-radius-small: var(--ax-token-radius-checkbox-s);
-  --ax-public-checkbox-border-radius-extra-small: var(--ax-token-radius-checkbox-xs);
+  --ax-public-checkbox-border-radius-extra-small: var(
+    --ax-token-radius-checkbox-xs
+  );
 
   --ax-public-checkbox-border-width: 0.0625rem;
 
   --ax-public-checkbox-border-color: var(--ax-ui-stroke-secondary-default);
   --ax-public-checkbox-bg: var(--ax-ui-bg-primary-default);
-  --ax-public-checkbox-icon-color: var(--ax-colors-gray-100); /* missing token */
+  --ax-public-checkbox-icon-color: var(
+    --ax-colors-gray-100
+  ); /* missing token */
 
   --ax-public-checkbox-checked-bg: var(--ax-ui-bg-tertiary-selected);
 
-  --ax-public-checkbox-focus-border-color: var(--ax-ui-stroke-secondary-default);
+  --ax-public-checkbox-focus-border-color: var(
+    --ax-ui-stroke-secondary-default
+  );
   --ax-public-checkbox-focus-border-shadow: var(--ax-txt-primary-default);
 
   --ax-public-checkbox-disabled-bg: var(--ax-ui-bg-tertiary-default);
-  --ax-public-checkbox-disabled-border-color: var(--ax-ui-stroke-secondary-default);
-  --ax-public-checkbox-disabled-icon-color: var(--ax-nav-button-icon-primary-disabled);
+  --ax-public-checkbox-disabled-border-color: var(
+    --ax-ui-stroke-secondary-default
+  );
+  --ax-public-checkbox-disabled-icon-color: var(
+    --ax-nav-button-icon-primary-disabled
+  );
 }
 
 .container {
@@ -69,7 +79,8 @@
   display: inline-block;
   position: relative;
   margin: 0;
-  border: var(--ax-public-checkbox-border-width) solid var(--ax-public-checkbox-border-color);
+  border: var(--ax-public-checkbox-border-width) solid
+    var(--ax-public-checkbox-border-color);
   background-color: white;
   cursor: pointer;
   vertical-align: middle;

--- a/packages/ui/src/components/checkbox/checkbox.tsx
+++ b/packages/ui/src/components/checkbox/checkbox.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import styles from './checkbox.module.css';
 
-import { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes } from 'react';
 import { Check, Minus } from '@phosphor-icons/react';
-import { SelectorSize } from '@ui/shared/types/selector-size';
+import type { SelectorSize } from '@ui/shared/types/selector-size';
 
 type Props = {
   /**

--- a/packages/ui/src/components/modal/modal.tsx
+++ b/packages/ui/src/components/modal/modal.tsx
@@ -4,9 +4,9 @@ import { Modal as BaseModal } from '@mui/base/Modal';
 import { forwardRef, type ReactNode } from 'react';
 import { NavButton } from '@ui/components/button/nav-button/nav-button';
 import { Fade } from '@mui/material';
-import { WithIcon } from '@ui/shared/types/with-icon';
+import type { WithIcon } from '@ui/shared/types/with-icon';
 import { X } from '@phosphor-icons/react';
-import { FooterVariant } from './types';
+import type { FooterVariant } from './types';
 
 type ModalProps = Partial<WithIcon> & {
   /**

--- a/packages/website/docs/components/checkbox/checkbox-docs.tsx
+++ b/packages/website/docs/components/checkbox/checkbox-docs.tsx
@@ -7,9 +7,9 @@ export function CheckboxDocs() {
     <ComponentPage
       preview={
         <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+          <Checkbox size="extra-small" />
           <Checkbox size="small" />
           <Checkbox size="medium" />
-          <Checkbox size="extra-small" />
           <Checkbox indeterminate />
           <Checkbox disabled />
           <Checkbox disabled checked />


### PR DESCRIPTION
We used large, small, and blank (default). The error occurred when switching to medium (default), small, and extra-small.

![obraz](https://github.com/user-attachments/assets/6b3d53a3-716f-41fd-a891-da70b856d431)

### Before
![Bez nazwy](https://github.com/user-attachments/assets/15a05891-7e37-417a-a6de-63bad5fb5100)

### After
![obraz](https://github.com/user-attachments/assets/dee115f4-d415-4327-a30b-a04fc876dc44)
