### PR TITLE
RFL-68 A modal without a footer has rounded corners at the bottom

### DIFF
--- a/packages/ui/src/components/modal/modal.module.css
+++ b/packages/ui/src/components/modal/modal.module.css
@@ -160,6 +160,7 @@
     gap: var(--ax-public-modal-content-gap);
     align-self: stretch;
     background: var(--ax-public-modal-content-background);
+    border-radius: var(--ax-public-modal-border-radius);
   }
 
   .footer {


### PR DESCRIPTION
## Before
![obraz](https://github.com/user-attachments/assets/c7c35043-fbaa-403e-a4d8-6a69f4d45f7a)

## After
![obraz](https://github.com/user-attachments/assets/e27c8ec9-1612-47c0-aa90-b3dd1c23670f)

Previously, setting `overflow: hidden` on the modal solved this issue, but we removed it to allow select options to be displayed over the modal (this PR: https://github.com/synergycodes/axiom/pull/66 ).