### PR TITLE
WB-112 change cursor to text on the whole input

### DIFF
--- a/packages/ui/src/components/input/input-root.module.css
+++ b/packages/ui/src/components/input/input-root.module.css
@@ -2,6 +2,7 @@
   .input-root {
     display: flex;
     align-items: center;
+    cursor: text;
 
     color: var(--ax-public-input-root-color);
 


### PR DESCRIPTION
Previously, on the edges of the inputs there was a wrong cursor displayed:


https://github.com/user-attachments/assets/4ebc48e5-7b3c-4ce3-ab29-a048065ed485


Now the whole container has the proper "text" cursor:

https://github.com/user-attachments/assets/8c807971-2bcb-4c84-908b-f30a08c10897

